### PR TITLE
Fix missing dozer configuration in REST

### DIFF
--- a/library-rest/src/main/java/cz/muni/fi/pa165/library/LibraryApplication.java
+++ b/library-rest/src/main/java/cz/muni/fi/pa165/library/LibraryApplication.java
@@ -1,7 +1,10 @@
 package cz.muni.fi.pa165.library;
 
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.Mapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
@@ -11,4 +14,10 @@ public class LibraryApplication {
     public static void main(String[] args) {
         SpringApplication.run(LibraryApplication.class, args);
     }
+
+    @Bean
+    public Mapper mapper() {
+        return DozerBeanMapperBuilder.buildDefault();
+    }
+    
 }

--- a/library-service/pom.xml
+++ b/library-service/pom.xml
@@ -19,13 +19,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.github.dozermapper/dozer-core -->
-        <dependency>
-            <groupId>com.github.dozermapper</groupId>
-            <artifactId>dozer-core</artifactId>
-            <version>6.5.0</version>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
             <version>2.0.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.github.dozermapper/dozer-core -->
+        <dependency>
+            <groupId>com.github.dozermapper</groupId>
+            <artifactId>dozer-core</artifactId>
+            <version>6.5.0</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
The controllers needed a facade, which in turn needed the service
implementation, which needed the missing dozer. After configuration the
Tomcat server starts successfully.

Also moved dozer dependency from library-persistance to project pom.xml.